### PR TITLE
Fix race condition when request config changes

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -99,52 +99,6 @@ export default class Fetch extends React.Component {
     }
   }
 
-  onResponseReceived = info => {
-    const {
-      error,
-      response,
-      hittingNetwork,
-      url,
-      init,
-      requestKey,
-      responseType
-    } = info;
-
-    this.responseReceivedInfo = null;
-    this.hasHandledResponse = true;
-
-    const data =
-      response && response.data
-        ? this.props.transformResponse(response.data)
-        : null;
-
-    if (hittingNetwork) {
-      this.props.afterFetch({
-        url,
-        init,
-        fetchDedupeConfig: { requestKey, responseType },
-        error,
-        response,
-        data,
-        didUnmount: this.willUnmount
-      });
-    }
-
-    if (this.willUnmount) {
-      return;
-    }
-
-    this.setState(
-      {
-        data,
-        error,
-        response,
-        fetching: false
-      },
-      () => this.props.onResponse(error, response)
-    );
-  };
-
   fetchData = (options, ignoreCache) => {
     const {
       fetchPolicy,
@@ -270,6 +224,52 @@ export default class Fetch extends React.Component {
 
         return error;
       }
+    );
+  };
+
+  onResponseReceived = info => {
+    const {
+      error,
+      response,
+      hittingNetwork,
+      url,
+      init,
+      requestKey,
+      responseType
+    } = info;
+
+    this.responseReceivedInfo = null;
+    this.hasHandledResponse = true;
+
+    const data =
+      response && response.data
+        ? this.props.transformResponse(response.data)
+        : null;
+
+    if (hittingNetwork) {
+      this.props.afterFetch({
+        url,
+        init,
+        fetchDedupeConfig: { requestKey, responseType },
+        error,
+        response,
+        data,
+        didUnmount: this.willUnmount
+      });
+    }
+
+    if (this.willUnmount) {
+      return;
+    }
+
+    this.setState(
+      {
+        data,
+        error,
+        response,
+        fetching: false
+      },
+      () => this.props.onResponse(error, response)
     );
   };
 }

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -73,31 +73,26 @@ export default class Fetch extends React.Component {
     const nextRequestKey = getRequestKey(nextProps);
 
     if (currentRequestKey !== nextRequestKey) {
-      // When a request is already in flight, and a new one is
-      // configured, then we need to "cancel" the previous one.
-      if (this.fetching && !this.hasHandledResponse) {
-        this.onResponseReceived({
-          ...this.responseReceivedInfo,
-          error: new Error('Request configuration changed'),
-          hittingNetwork: true
-        });
-      }
-
       this.fetchData(nextProps);
     }
   }
 
   componentWillUnmount() {
     this.willUnmount = true;
+    this.cancelExistingRequest('Component unmounted');
+  }
 
-    if (this.fetching && !this.hasHandledResponse) {
+  // When a request is already in flight, and a new one is
+  // configured, then we need to "cancel" the previous one.
+  cancelExistingRequest = reason => {
+    if (this.state.fetching && !this.hasHandledResponse) {
       this.onResponseReceived({
         ...this.responseReceivedInfo,
-        error: new Error('Component unmounted'),
+        error: new Error(reason),
         hittingNetwork: true
       });
     }
-  }
+  };
 
   fetchData = (options, ignoreCache) => {
     const {
@@ -107,6 +102,8 @@ export default class Fetch extends React.Component {
       beforeFetch,
       afterFetch
     } = this.props;
+
+    this.cancelExistingRequest('New fetch specified');
 
     const {
       url,

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -19,10 +19,10 @@ export default class Fetch extends React.Component {
         render({
           requestName,
           url,
-          fetching: fetching,
-          response: response,
-          data: data,
-          error: error,
+          fetching,
+          response,
+          data,
+          error,
           doFetch: opts => this.fetchData(opts, true)
         }) || null
       );


### PR DESCRIPTION
Me thinking about writing tests for this: 😭 

There's a lot here. Here's how it works:

**1st problem:**
When a request config changes, a second request can be kicked off before the first completes. To resolve this, the response callback is called with an error just before that second request begins.

**This causes a new problem:**
This causes another issue. We could now have two response handlers called. The solution is `hasHandledResponse`, which tracks whether that method has been called for a particular request or not.

**Another, separate problem:**

I also realized that the request is not "aborted" on unmount, so I added in that as well.

---

Resolves #68 